### PR TITLE
Add ignore visible for child components

### DIFF
--- a/src/ExportCommand.php
+++ b/src/ExportCommand.php
@@ -16,6 +16,7 @@ class ExportCommand extends Command
     {
         $this->setName('export')
             ->addOption('component-id', null, InputOption::VALUE_REQUIRED, 'Component ID where the export should start.', 'root')
+            ->addOption('addInvisibleChildComponents', 'aiccmp', InputOption::VALUE_OPTIONAL, 'Include all invisible child-components.')
             ->setDescription('Export Component Content');
     }
 
@@ -30,6 +31,9 @@ class ExportCommand extends Command
 
         while (true) {
             $cmd = "php vendor/bin/component-content-import-export export:worker";
+            if ($input->hasOption('addInvisibleChildComponents')) {
+                $cmd .= " --addInvisibleChildComponents";
+            }
             $process = new Process($cmd);
 
             $process->setTimeout(null);

--- a/src/ExportWorkerCommand.php
+++ b/src/ExportWorkerCommand.php
@@ -3,6 +3,7 @@ namespace ComponentContentImportExport;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
@@ -11,6 +12,7 @@ class ExportWorkerCommand extends Command
     protected function configure()
     {
         $this->setName('export:worker')
+            ->addOption('addInvisibleChildComponents', 'aiccmp', InputOption::VALUE_OPTIONAL, 'Include all invisible child-components.')
             //->setHidden(true)
         ;
     }
@@ -54,8 +56,9 @@ class ExportWorkerCommand extends Command
                 $errOutput->writeLn(" :: $page->url");
             }
 
-            $childPages = $page->getChildComponents();
-            foreach ($childPages as $c) {
+            $select = new \Kwf_Component_Select();
+            if ($input->hasOption('addInvisibleChildComponents')) $select->ignoreVisible(true);
+            foreach ($page->getChildComponents($select) as $c) {
                 if ($c->parent->componentId != $page->componentId) continue; //skip unique box under other parent
                 $errOutput->writeLn("queued $c->componentId", OutputInterface::VERBOSITY_VERBOSE);
                 $queue[] = $c->componentId;


### PR DESCRIPTION
as trl-content should probably stay hidden before it's translated.